### PR TITLE
Add "Add a New Server" button to NavigationView footer

### DIFF
--- a/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml
+++ b/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml
@@ -46,9 +46,24 @@
                 <NavigationViewItem Content="Settings" Tag="SettingsPage" Icon="Setting" />
             </NavigationView.MenuItems>
 
+            <NavigationView.PaneFooter>
+                <Grid Margin="12,8,12,12">
+                    <Button
+                        x:Name="addServerButton"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Content="Add a New Server"
+                        Click="AddServerButton_Clicked"
+                        HorizontalAlignment="Stretch"
+                        Height="36"
+                        Padding="8,6" />
+                </Grid>
+            </NavigationView.PaneFooter>
+
+
             <NavigationView.Content>
                 <Frame x:Name="contentFrame" />
             </NavigationView.Content>
+
 
             <NavigationView.KeyboardAccelerators>
                 <KeyboardAccelerator Key="N" Modifiers="Control" Invoked="CtrlN_Invoked"/>

--- a/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml.cs
+++ b/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml.cs
@@ -218,5 +218,38 @@ namespace paradigm_ehb.CommandCenter.WinUI
 
             ContentDialogResult result = await serverCreationDialog.ShowAsync();
         }
+        private async void AddServerButton_Clicked(object sender, RoutedEventArgs args)
+        {
+            var serverCreation = new ServerCreation();
+
+            ContentDialog serverCreationDialog = new ContentDialog
+            {
+                Title = "Add a new server",
+                Content = serverCreation,
+                CloseButtonText = "OK",
+                PrimaryButtonText = "Cancel",
+                XamlRoot = this.Content.XamlRoot
+            };
+
+            serverCreationDialog.Closing += (dialog, closingArgs) => {
+                if (closingArgs.Result == ContentDialogResult.None)
+                {
+                    bool isValid = serverCreation.ValidateAndProcess();
+
+                    // Cancel the close if validation fails
+                    if (!isValid)
+                    {
+                        closingArgs.Cancel = true;
+                    }
+                    else
+                    {
+                        HomePage.Instance.LoadServers();
+                        LoadServerMenu();
+                    }
+                }
+            };
+
+            ContentDialogResult result = await serverCreationDialog.ShowAsync();
+        }
     }
 }


### PR DESCRIPTION
Added an accent-styled "Add a New Server" button to the NavigationView pane footer in MainWindow.xaml. Implemented the AddServerButton_Clicked handler to open a server creation dialog with input validation. The server list refreshes upon successful addition. This improves accessibility for adding servers directly from the main navigation pane.