### PR TITLE
Move Ctrl+N shortcut to Add Server button

### DIFF
--- a/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml
+++ b/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml
@@ -55,7 +55,11 @@
                         Click="AddServerButton_Clicked"
                         HorizontalAlignment="Stretch"
                         Height="36"
-                        Padding="8,6" />
+                        Padding="8,6">
+                        <Button.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="N" Modifiers="Control" />
+                        </Button.KeyboardAccelerators>
+                    </Button>
                 </Grid>
             </NavigationView.PaneFooter>
 
@@ -65,9 +69,6 @@
             </NavigationView.Content>
 
 
-            <NavigationView.KeyboardAccelerators>
-                <KeyboardAccelerator Key="N" Modifiers="Control" Invoked="CtrlN_Invoked"/>
-            </NavigationView.KeyboardAccelerators>
         </NavigationView>
     </Grid>
 </Window>

--- a/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml.cs
+++ b/src/paradigm-ehb.CommandCenter.WinUI/MainWindow.xaml.cs
@@ -182,42 +182,7 @@ namespace paradigm_ehb.CommandCenter.WinUI
             contentFrame.Navigate(typeof(HomePage));
 
         }
-
-        private async void CtrlN_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        {
-            args.Handled = true;
-
-            var serverCreation = new ServerCreation();
-
-            ContentDialog serverCreationDialog = new ContentDialog
-            {
-                Title = "Add a new server",
-                Content = serverCreation,
-                CloseButtonText = "OK",
-                PrimaryButtonText = "Cancel",
-                XamlRoot = this.Content.XamlRoot
-            };
-
-            serverCreationDialog.Closing += (dialog, closingArgs) => {
-                if (closingArgs.Result == ContentDialogResult.None)
-                {
-                    bool isValid = serverCreation.ValidateAndProcess();
-
-                    // Cancel the close if validation fails
-                    if (!isValid)
-                    {
-                        closingArgs.Cancel = true;
-                    }
-                    else
-                    {
-                        HomePage.Instance.LoadServers();
-                        LoadServerMenu();
-                    }
-                }
-            };
-
-            ContentDialogResult result = await serverCreationDialog.ShowAsync();
-        }
+        
         private async void AddServerButton_Clicked(object sender, RoutedEventArgs args)
         {
             var serverCreation = new ServerCreation();


### PR DESCRIPTION
Ctrl+N now triggers the Add Server button directly, improving shortcut handling. Removed global NavigationView shortcut and merged its logic into the button's click event handler for better code clarity and user experience.