### PR TITLE
Feat/server services view

### DIFF
--- a/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/ServerMainPage.xaml
+++ b/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/ServerMainPage.xaml
@@ -47,7 +47,7 @@
                      Text="Overview" Icon="Clock">
                 </SelectorBarItem>
                 <SelectorBarItem x:Name="SelectorBarItemServices" 
-                     Text="Services" Icon="Share"/>
+                     Text="Services" Icon="AllApps"/>
                 <SelectorBarItem x:Name="SelectorBarItemProcesses" 
                      Text="Processes" Icon="Favorite"/>
             </SelectorBar>

--- a/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServiceDetailsWindow.xaml.cs
+++ b/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServiceDetailsWindow.xaml.cs
@@ -130,6 +130,26 @@ namespace paradigm_ehb.CommandCenter.WinUI.srvMgnt.Views
                     call?.Dispose();
                 }
                 catch { /* best-effort cleanup */ }
+
+                // If no logs were produced, show a centered placeholder message.
+                try
+                {
+                    _ = DispatcherQueue.TryEnqueue(() =>
+                    {
+                        if (string.IsNullOrWhiteSpace(ServiceLogs.Text))
+                        {
+                            ServiceLogs.Text = "No logs available";
+                            // Center the message within the control/window as best-effort.
+                            ServiceLogs.TextAlignment = global::Microsoft.UI.Xaml.TextAlignment.Center;
+                            ServiceLogs.HorizontalAlignment = global::Microsoft.UI.Xaml.HorizontalAlignment.Center;
+                            ServiceLogs.VerticalAlignment = global::Microsoft.UI.Xaml.VerticalAlignment.Center;
+                        }
+                    });
+                }
+                catch
+                {
+                    // swallow any UI-thread issues
+                }
             }
         }
     }

--- a/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServicesPage.xaml
+++ b/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServicesPage.xaml
@@ -23,12 +23,15 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="8" Grid.Row="0">
             <Button x:Name="RefreshButton"
-                    Content="Refresh"
                     Click="RefreshButton_Click"
                     VerticalAlignment="Center"
                     HorizontalAlignment="Right"
-                    Margin="0,0,4,0"/>
+                    Margin="0,0,4,0">
+                <SymbolIcon Symbol="Refresh"/>
+            </Button>
         </StackPanel>
+
+        <ProgressRing x:Name="LoadingProgressRing" Grid.Row="1" IsActive="True" Width="48" Height="48"/>
 
         <ListView
             ItemsSource="{x:Bind services, Mode=OneWay}"

--- a/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServicesPage.xaml.cs
+++ b/src/paradigm-ehb.CommandCenter.WinUI/srvMgnt/Views/ServicesPage.xaml.cs
@@ -45,7 +45,9 @@ namespace paradigm_ehb.CommandCenter.WinUI.srvMgnt.Views
         private async void RefreshButton_Click(object sender, RoutedEventArgs e)
         {
             await ClearAllServices();
+            LoadingProgressRing.IsActive = true;
             await LoadAllServices();
+            LoadingProgressRing.IsActive = false;
         }
 
 
@@ -259,6 +261,8 @@ namespace paradigm_ehb.CommandCenter.WinUI.srvMgnt.Views
                 }
 
                 await LoadAllServices();
+
+                LoadingProgressRing.IsActive = false;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This pull request improves the user experience and reliability of the service management UI by enhancing feedback, clarifying actions, and refining the interface. The most significant changes include improved loading indicators, confirmation dialogs for critical actions, and better handling of empty log displays.

**User Interface and Feedback Improvements:**

* Added a `ProgressRing` (`LoadingProgressRing`) to `ServicesPage.xaml` to visually indicate when services are loading, and updated the code to activate/deactivate it during load and refresh operations. [[1]](diffhunk://#diff-f80aacfc53bc548738900504946652f7c4a6c08be50cb37e3f1fa5047aaf5ba7L26-R35) [[2]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2R48-R50) [[3]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2R264-R265)
* Updated the "Refresh" button on the services page to use a refresh icon for a more modern and intuitive look.
* When no logs are available in the service details window, a centered placeholder message ("No logs available") is now shown to inform the user.

**Service Action Handling and Safety:**

* Added a confirmation dialog before stopping a service, requiring explicit user confirmation to prevent accidental stops. The dialog includes "Cancel" and "Kill" options. [[1]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2L82-R96) [[2]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2R111-R115)
* Improved null-safety and error handling in service action commands by using null-forgiving operators and clearer exception handling in restart scenarios. [[1]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2L59-R61) [[2]](diffhunk://#diff-acb4c4a0b284a5eabcad9bce249149aa4f71b9d41d059445229371ae518b05c2L128-R148)

**Minor UI Consistency:**

* Changed the "Services" icon in the main selector bar from "Share" to "AllApps" for better visual consistency.